### PR TITLE
origin/bugfix-br

### DIFF
--- a/src/templates/film-details.hbs
+++ b/src/templates/film-details.hbs
@@ -28,7 +28,6 @@
         {{else}}
           <img
             class='film-card__img-zaglushka film-image'
-            style='height:auto'
             loading="lazy"
             src='https://i.postimg.cc/6pzyh7Wc/pngwing-com.png'
             alt='film poster'


### PR DESCRIPTION
Прибираю стиль який прописаний у розмітці хендлбару і ламає розмір заглушок карточок до яких немає картинок