### PR TITLE
Update _footer-modal.scss

### DIFF
--- a/src/sass/modal/_footer-modal.scss
+++ b/src/sass/modal/_footer-modal.scss
@@ -153,4 +153,14 @@
   right: 5px;
   height: 35px;
   width: 50px;
+  &:hover,
+  &:focus {
+    background-color: $accent-color;
+    transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1);
+  }
+}
+.close-button-svg:hover,
+:focus {
+  background-color: $accent-color;
+  transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1);
 }


### PR DESCRIPTION
добавила ховер-фокус на значок гитхаба и крестик закрытия модалки. но там окрашивается не сам значок, а квадратик полностью